### PR TITLE
Add Mercury DEX RFP Proposal to Dev Dept Internal meetings Agenda

### DIFF
--- a/departments/development/events/Meeting/20240507-Internal-Agenda.md
+++ b/departments/development/events/Meeting/20240507-Internal-Agenda.md
@@ -122,6 +122,7 @@
 
 1. Council Meeting Recap
 1. RFP Presentation Recap
+1. Mercury DEX Proposal (RFP#6 Submission#1)
 
 ## TABLED ITEMS (pushed to a future meeting)
 


### PR DESCRIPTION
Based on the last Council meeting minutes, Dev Dept is taking from Ops Dept the Community Dex RFP process.