### PR TITLE
Add Conflict of Interest policy to the Charter amendments

### DIFF
--- a/charter/DRAFT-H-CONFLICT_OF_INTEREST.md
+++ b/charter/DRAFT-H-CONFLICT_OF_INTEREST.md
@@ -1,0 +1,37 @@
+# AMENDMENT H: CONFLICT OF INTEREST
+
+This policy should replace `Section V.9 — Conflicts of Interest` of the Juno Charter (`00-CHARTER.md`).
+
+## Conflict Of Interest policy
+
+1. Any Juno Council Department member should disclose immediately or as soon as it becomes relevant, if he has any potential Conflict Of Interest (COI), defined as:
+
+    1. on-chain compensation from an entity surpassing compensation from the Council, its Departments & SubDAOs, on a monthly basis, excluding staking rewards;
+    2. ownership or governance rights of an entity that is entering an agreement with, or receiving any funding, delegation or token from, the Department or its SubDAOs;
+    3. direct or indirect control of at least 0.5% of the current total supply of an entity's native token whose trading volume is more than the compensation of all members.
+
+2. Any proposal made by the member to his Department (or any of its SubDAOs) regarding such entities must note the proposer COI in its on-chain text.
+
+3. The member with COI must vote ABSTAIN (or abstain from voting) on Department's (or any of its sub-DAOs') proposals regarding such entities; the member might participate in public discussions regarding such proposals only after remarking his COI. 
+
+4. Members of the Council and its SubDAOs cannot accept gifts and won't individually claim, transfer or use unsolicited airdropped tokens in any way during their mandate.
+
+### Methodology
+
+5. COI as defined above should be disclosed by the subject member with an on-chain proposal to his Department, titled `Conflict Of Interest Disclosure` or `COI Disclosure update` and listing the ID or linked brand name of entities defined above for each month or for an indefinite period: in the latter case, the COI is valid until the member is removed or posts a new COI.
+
+6. Compensations & trading volumes are compared at their single most exchanged pair or route over the last 28 days (UTC closings average price & total volume).
+
+### Monitoring & Consequences
+
+7. To allow "transparency agents" to report undisclosed COI and violations of this policy, the Council must provide a publicly-accessible & free-to-submit `COI Reporting` form:
+    1. its submissions should be visible only to Council members (to avoid public defamation) for 28 days (during which public remedy actions might be taken), and to the public afterwards;
+    2. the Council should set its URL as value of a `COI_Reporting` *storage item* on its DAO and link it on a publicly accessible & immutable content together with this policy.
+
+8. To incentivise reporters and disincentivize violations, the Council must freeze its compensation to the subject member until relevant submissions are verified, and redirect it to the reporter with a proposal that, when passed, confirms the veridicity of the report.
+
+9. When failing to comply with any of points 1 to 5 above, the member should be removed from the Council, Department and its SubDAOs and stop receiving related compensations.
+
+### Unforeseen conflicts
+
+10. This present policy tries to defend Juno community by prescribing duties for Council members, but it's important to remind that anyone may at anytime submit a Juno Governance Proposal directly to all JUNO stake-holders to report unforeseen conflicts, suggest remedies or improvements, veto or override Council's decisions in general.

--- a/charter/DRAFT-H-CONFLICT_OF_INTEREST.md
+++ b/charter/DRAFT-H-CONFLICT_OF_INTEREST.md
@@ -1,6 +1,6 @@
 # AMENDMENT H: CONFLICT OF INTEREST
 
-This policy should replace `Section V.9 — Conflicts of Interest` of the Juno Charter (`00-CHARTER.md`).
+This policy should replace `Section V.9 — Conflicts of Interest` of the Juno Charter.
 
 ## Conflict Of Interest policy
 

--- a/charter/README.md
+++ b/charter/README.md
@@ -21,3 +21,4 @@ The Charter is a living document, and it can be amended by the community through
 - [Amendment E: Delegate Integrity](./DRAFT-E-DELEGATE_INTEGRITY.md)
 - [Amendment F: Delegate Remuneration](./DRAFT-F-DELEGATE_REMUNERATION.md)
 - [Amendment G: Charter Amendment Process](./DRAFT-G-AMENDMENT_PROCESS.md)
+- [Amendment H: Conflict Of Interest policy](./DRAFT-H-CONFLICT_OF_INTEREST.md)


### PR DESCRIPTION
I suggest we swap the current `Section V.9 — Conflicts of Interest` of the Charter with the [draft COI policy](https://github.com/CosmosContracts/council/blob/main/policies/DRAFT-01-CONFLICT_OF_INTEREST.md) (without the explanations, example implementations, rationales), by adding the `DRAFT-H-CONFLICT_OF_INTEREST.md`.

You can read the history of this policy draft in the apposite [working group Discord channel](https://discord.com/channels/816256689078403103/1218118656915931226) and in [PR#17](https://github.com/CosmosContracts/council/pull/17).
